### PR TITLE
Allow whitespace in siteswaps

### DIFF
--- a/public/js/Siteswap.js
+++ b/public/js/Siteswap.js
@@ -267,6 +267,7 @@ exports.CreateSiteswap = function(siteswapStr, options) {
 
 	/* check that the siteswap has the correct syntax */
 	function validateSyntax() {
+		siteswapStr = siteswapStr.replace(/\s/g,"");
 		var numJugglers = 1;
 		var isPassingPattern = /<[^ ]+>/.test(siteswapStr);
 


### PR DESCRIPTION
As an added convenience, siteswaps formatted with generous whitespace (for example, with spaces after the comma in synchronous notation: e.g. `(6, 4)`) should be accepted.